### PR TITLE
replace use of global Contao namespaces

### DIFF
--- a/FormMPFormPageSwitch.php
+++ b/FormMPFormPageSwitch.php
@@ -9,7 +9,9 @@
  * @link       https://github.com/terminal42/contao-mp_forms
  */
 
-class FormMPFormPageSwitch extends \Widget
+use Contao\Widget;
+
+class FormMPFormPageSwitch extends Widget
 {
     /**
      * Template

--- a/MPForms.php
+++ b/MPForms.php
@@ -9,16 +9,23 @@
  * @link       https://github.com/terminal42/contao-mp_forms
  */
 
+use Contao\Controller;
+use Contao\Form;
+use Contao\FormFieldModel;
+use Contao\FormModel;
+use Contao\Input;
+use Contao\Widget;
+
 class MPForms
 {
     /**
      * Adjust form fields to given page.
      *
-     * @param \FormFieldModel[] $formFields
-     * @param string            $formId
-     * @param \Form             $form
+     * @param FormFieldModel[] $formFields
+     * @param string           $formId
+     * @param Form             $form
      */
-    public function compileFormFields($formFields, $formId, \Form $form)
+    public function compileFormFields($formFields, $formId, Form $form)
     {
         // Make sure empty form fields arrays are skipped
         if (0 === count($formFields)) {
@@ -56,7 +63,7 @@ class MPForms
         // If someone wanted to skip the page, fake form submission so fields
         // are validated and show the error message.
         if ($manager->getPreviousStepsWereInvalid()) {
-            \Input::setPost('FORM_SUBMIT', $manager->getFormId());
+            Input::setPost('FORM_SUBMIT', $manager->getFormId());
             $manager->resetPreviousStepsWereInvalid();
         }
 
@@ -67,14 +74,14 @@ class MPForms
      * Loads the values from the session and adds it as default value to the
      * widget.
      *
-     * @param \Widget $widget
-     * @param string  $formId
-     * @param array   $formData
-     * @param \Form    $form
+     * @param Widget $widget
+     * @param string $formId
+     * @param array  $formData
+     * @param Form   $form
      *
-     * @return \Widget
+     * @return Widget
      */
-    public function loadValuesFromSession($widget, $formId, $formData, \Form $form)
+    public function loadValuesFromSession(Widget $widget, $formId, $formData, Form $form)
     {
         $manager = new MPFormsFormManager($form->id);
 
@@ -97,7 +104,7 @@ class MPForms
     public function prepareFormData(&$submitted, &$labels, $fieldsOrForm, $formOrFields)
     {
         // Compat with Contao 4 and 3.5
-        $form = $fieldsOrForm instanceof \Form ? $fieldsOrForm : $formOrFields;
+        $form = $fieldsOrForm instanceof Form ? $fieldsOrForm : $formOrFields;
 
         $manager = new MPFormsFormManager($form->id);
 
@@ -161,7 +168,7 @@ class MPForms
         $formId = $chunks[1];
         $value = $chunks[2];
 
-        $form = \FormModel::findByPk($formId);
+        $form = FormModel::findByPk($formId);
         $manager = new MPFormsFormManager($form->id);
 
         switch ($value) {
@@ -184,6 +191,6 @@ class MPForms
      */
     private function redirectToStep(MPFormsFormManager $manager, $step)
     {
-        \Controller::redirect($manager->getUrlForStep($step));
+        Controller::redirect($manager->getUrlForStep($step));
     }
 }

--- a/MPFormsFormManager.php
+++ b/MPFormsFormManager.php
@@ -9,15 +9,25 @@
  * @link       https://github.com/terminal42/contao-mp_forms
  */
 
+use Contao\Form;
+use Contao\FormCaptcha;
+use Contao\FormFieldModel;
+use Contao\FormModel;
+use Contao\Input;
+use Contao\Session;
+use Contao\System;
+use Contao\Widget;
+use Haste\Util\Url;
+
 class MPFormsFormManager
 {
     /**
-     * @var \FormModel
+     * @var FormModel
      */
     private $formModel;
 
     /**
-     * @var \FormFieldModel[]
+     * @var FormFieldModel[]
      */
     private $formFieldModels;
 
@@ -42,7 +52,7 @@ class MPFormsFormManager
      */
     function __construct($formGeneratorId)
     {
-        $this->formModel = \FormModel::findByPk($formGeneratorId);
+        $this->formModel = FormModel::findByPk($formGeneratorId);
 
         $this->prepareFormFields();
     }
@@ -164,7 +174,7 @@ class MPFormsFormManager
      */
     public function getCurrentStep()
     {
-        return (int) \Input::get($this->getGetParam());
+        return (int) Input::get($this->getGetParam());
     }
 
     /**
@@ -239,9 +249,9 @@ class MPFormsFormManager
     public function getUrlForStep($step)
     {
         if (0 === $step) {
-            $url = \Haste\Util\Url::removeQueryString([$this->getGetParam()]);
+            $url = Url::removeQueryString([$this->getGetParam()]);
         } else {
-            $url = \Haste\Util\Url::addQueryString($this->getGetParam() . '=' . $step);
+            $url = Url::addQueryString($this->getGetParam() . '=' . $step);
         }
 
         return $url;
@@ -376,12 +386,12 @@ class MPFormsFormManager
     /**
      * Validates a field.
      *
-     * @param \FormFieldModel $formField
+     * @param FormFieldModel $formField
      * @param int             $step
      *
      * @return bool
      */
-    public function validateField(\FormFieldModel $formField, $step)
+    public function validateField(FormFieldModel $formField, $step)
     {
         $class = $GLOBALS['TL_FFL'][$formField->type];
 
@@ -389,7 +399,7 @@ class MPFormsFormManager
             return true;
         }
 
-        /** @var \Widget $widget */
+        /** @var Widget $widget */
         $widget = new $class($formField->row());
         $widget->required = $formField->mandatory ? true : false;
         $widget->decodeEntities = true; // Always decode entities
@@ -400,7 +410,7 @@ class MPFormsFormManager
         // HOOK: load form field callback
         if (isset($GLOBALS['TL_HOOKS']['loadFormField']) && is_array($GLOBALS['TL_HOOKS']['loadFormField'])) {
             foreach ($GLOBALS['TL_HOOKS']['loadFormField'] as $callback) {
-                $objCallback = \System::importStatic($callback[0]);
+                $objCallback = System::importStatic($callback[0]);
                 $widget = $objCallback->{$callback[1]}($widget, $this->getFormId(), $this->formModel->row(), $form);
             }
         }
@@ -420,7 +430,7 @@ class MPFormsFormManager
                 $value = '';
             }
 
-            \Input::setPost($formField->name, $value);
+            Input::setPost($formField->name, $value);
             $fakeValidation = true;
         }
 
@@ -428,7 +438,7 @@ class MPFormsFormManager
 
         // Reset fake validation
         if ($fakeValidation) {
-            \Input::setPost($formField->name, null);
+            Input::setPost($formField->name, null);
         }
 
         // Special hack for upload fields because they delete $_FILES and thus
@@ -441,7 +451,7 @@ class MPFormsFormManager
         if (isset($GLOBALS['TL_HOOKS']['validateFormField']) && is_array($GLOBALS['TL_HOOKS']['validateFormField'])) {
             foreach ($GLOBALS['TL_HOOKS']['validateFormField'] as $callback) {
 
-                $objCallback = \System::importStatic($callback[0]);
+                $objCallback = System::importStatic($callback[0]);
                 $widget = $objCallback->{$callback[1]}($widget, $this->getFormId(), $this->formModel->row(), $form);
             }
         }
@@ -513,7 +523,7 @@ class MPFormsFormManager
      *
      * @return bool
      */
-    public function isPageBreak(\FormFieldModel $formField)
+    public function isPageBreak(FormFieldModel $formField)
     {
         return 'mp_form_pageswitch' === $formField->type;
     }
@@ -524,11 +534,11 @@ class MPFormsFormManager
      *
      * @return bool
      */
-    private function checkWidgetSubmittedInCurrentStep(\Widget $widget)
+    private function checkWidgetSubmittedInCurrentStep(Widget $widget)
     {
         // Special handling for captcha field
-        if ($widget instanceof \FormCaptcha) {
-            $session = \Session::getInstance();
+        if ($widget instanceof FormCaptcha) {
+            $session = Session::getInstance();
             $captcha = $session->get('captcha_' . $widget->id);
 
             return isset($_POST[$captcha['key']]);
@@ -582,7 +592,7 @@ class MPFormsFormManager
      */
     private function loadFormFieldModels()
     {
-        $formFieldModels = \FormFieldModel::findPublishedByPid($this->formModel->id);
+        $formFieldModels = FormFieldModel::findPublishedByPid($this->formModel->id);
 
         if (null === $formFieldModels) {
             $formFieldModels = [];
@@ -601,7 +611,7 @@ class MPFormsFormManager
                     continue;
                 }
 
-                $objCallback = \System::importStatic($callback[0]);
+                $objCallback = System::importStatic($callback[0]);
                 $formFieldModels = $objCallback->{$callback[1]}($formFieldModels, $this->getFormId(), $form);
             }
         }
@@ -618,6 +628,6 @@ class MPFormsFormManager
     {
         $form = new stdClass();
         $form->form = $this->formModel->id;
-        return new \Form($form);
+        return new Form($form);
     }
 }

--- a/MPFormsStepsModule.php
+++ b/MPFormsStepsModule.php
@@ -9,7 +9,12 @@
  * @link       https://github.com/terminal42/contao-mp_forms
  */
 
-class MPFormsStepsModule extends \Module
+use Contao\Module;
+use Contao\BackendTemplate;
+use Contao\FrontendTemplate;
+use Haste\Generator\RowClass;
+
+class MPFormsStepsModule extends Module
 {
 
     /**
@@ -27,8 +32,8 @@ class MPFormsStepsModule extends \Module
     public function generate()
     {
         if (TL_MODE == 'BE') {
-            /** @var \BackendTemplate|object $objTemplate */
-            $objTemplate = new \BackendTemplate('be_wildcard');
+            /** @var BackendTemplate|object $objTemplate */
+            $objTemplate = new BackendTemplate('be_wildcard');
 
             $objTemplate->wildcard = '### ' . utf8_strtoupper($GLOBALS['TL_LANG']['FMD']['mp_form_steps'][0]) . ' ###';
             $objTemplate->title = $this->headline;
@@ -48,7 +53,7 @@ class MPFormsStepsModule extends \Module
      */
     protected function compile()
     {
-        $navTpl = new \FrontendTemplate($this->navigationTpl ?: 'nav_default');
+        $navTpl = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
         $navTpl->level = 0;
         $navTpl->items = $this->buildNavigationItems();
         $this->Template->navigation = $navTpl->parse();
@@ -88,7 +93,7 @@ class MPFormsStepsModule extends \Module
             ];
         }
 
-        \Haste\Generator\RowClass::withKey('class')
+        RowClass::withKey('class')
             ->addFirstLast()
             ->addEvenOdd()
             ->applyTo($items);


### PR DESCRIPTION
see #23 

All occurences of global Contao classes in the codebase have been replaced with there namespaced counterparts. + addition of one missing type constraint (`Widget`) for consistency.