### PR TITLE
reset faked post values at a later point

### DIFF
--- a/MPFormsFormManager.php
+++ b/MPFormsFormManager.php
@@ -426,11 +426,6 @@ class MPFormsFormManager
 
         $widget->validate();
 
-        // Reset fake validation
-        if ($fakeValidation) {
-            \Input::setPost($formField->name, null);
-        }
-
         // Special hack for upload fields because they delete $_FILES and thus
         // multiple validation calls will fail - sigh
         if ($widget instanceof \uploadable && isset($_SESSION['FILES'][$widget->name])) {
@@ -444,6 +439,11 @@ class MPFormsFormManager
                 $objCallback = \System::importStatic($callback[0]);
                 $widget = $objCallback->{$callback[1]}($widget, $this->getFormId(), $this->formModel->row(), $form);
             }
+        }
+        
+        // Reset fake validation
+        if ($fakeValidation) {
+            \Input::setPost($formField->name, null);
         }
 
         return !$widget->hasErrors();

--- a/MPFormsFormManager.php
+++ b/MPFormsFormManager.php
@@ -433,12 +433,6 @@ class MPFormsFormManager
 
         $widget->validate();
 
-        // Special hack for upload fields because they delete $_FILES and thus
-        // multiple validation calls will fail - sigh
-        if ($widget instanceof \uploadable && isset($_SESSION['FILES'][$widget->name])) {
-            $_FILES[$widget->name] = $_SESSION['FILES'][$widget->name];
-        }
-
         // HOOK: validate form field callback
         if (isset($GLOBALS['TL_HOOKS']['validateFormField']) && is_array($GLOBALS['TL_HOOKS']['validateFormField'])) {
             foreach ($GLOBALS['TL_HOOKS']['validateFormField'] as $callback) {
@@ -447,11 +441,17 @@ class MPFormsFormManager
                 $widget = $objCallback->{$callback[1]}($widget, $this->getFormId(), $this->formModel->row(), $form);
             }
         }
-        
+
         // Reset fake validation
         if ($fakeValidation) {
             Input::setPost($formField->name, null);
         }
+        
+        // Special hack for upload fields because they delete $_FILES and thus
+        // multiple validation calls will fail - sigh
+        if ($widget instanceof \uploadable && isset($_SESSION['FILES'][$widget->name])) {
+            $_FILES[$widget->name] = $_SESSION['FILES'][$widget->name];
+        }       
 
         return !$widget->hasErrors();
     }


### PR DESCRIPTION
When using `contao-mp_forms` in combination with `terminal42/contao-conditionalformfields` validation fails under certain conditions. 

## How to reproduce? ##

Create a simple two-page form like the following with a checkbox field `option` (label = option, value = 1) and a conditional fieldset containing a mandatory field that's only shown if the checkbox is not checked (condition: `$option != 1`) on the first page:

![screenshot_20180317_143348](https://user-images.githubusercontent.com/5305677/37555983-437b4dd6-29f0-11e8-9f01-7629c83bd8fe.png)

Run the form and try to go to the next step by checking the checkbox (nothing entered in the now hidden mandatory field). The validation for the step erroneously fails (stating nothing was entered in the mandatory field).


## Whats the problem? ##

`contao-mp_forms` clears the POST data when going to the next step but `contao-conditionalformfields` needs them in the _validate form field_ callback in order to remove previously set errors from widgets that are hidden by a condition. 


## Possible solution ##

This really is an interaction of two hacks that exist due to limitations of the Contao core, and the answer could as well be: That's expected when doing so.  :-)  However, as `contao-mp_forms` already fakes validation by temporarily setting post values, resetting them could simply be done after the _validate form field_ callback is called.

If you don't see any implications that simple adaption would probably save a lot of trouble when using both extensions. At least dor me. :grinning: 