### PR TITLE
Show original filename in "##mp_forms_summary##" token.

### DIFF
--- a/FormMPFormPlaceholder.php
+++ b/FormMPFormPlaceholder.php
@@ -118,8 +118,8 @@ class FormMPFormPlaceholder extends Widget
 
             // Generate a general HTML output using the download template
             $tpl = new \Contao\FrontendTemplate('ce_download'); // TODO: make configurable in form field settings?
-            $tpl->link = $file->basename;
-            $tpl->title = ContaoStringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['download'], $file->basename));
+            $tpl->link = $v['name'];
+            $tpl->title = ContaoStringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['download'], $v['name']));
             $tpl->href = $fileTokens['download_url'];
             $tpl->filesize = System::getReadableSize($file->filesize);
             $tpl->icon = Image::getPath($file->icon);


### PR DESCRIPTION
I think that it is better to show original filename instead of temporary filename.