### PR TITLE
Fix default value of sessionRefParam

### DIFF
--- a/dca/tl_form.php
+++ b/dca/tl_form.php
@@ -29,7 +29,7 @@ $GLOBALS['TL_DCA']['tl_form']['fields']['mp_forms_getParam'] = [
 
 $GLOBALS['TL_DCA']['tl_form']['fields']['mp_forms_sessionRefParam'] = [
     'exclude'   => true,
-    'default'   => 'step',
+    'default'   => 'ref',
     'inputType' => 'text',
     'eval'      => ['tl_class' => 'w50', 'maxlength' => 255],
     'sql'       => "varchar(255) NOT NULL default 'ref'"


### PR DESCRIPTION
Fixes https://github.com/terminal42/contao-mp_forms/issues/58 and https://github.com/terminal42/contao-mp_forms/issues/56

When I created a form, I had `step` as the default value for both query parameters.