### PR TITLE
Fix default field value

### DIFF
--- a/src/EventListener/LoadFormFieldListener.php
+++ b/src/EventListener/LoadFormFieldListener.php
@@ -35,7 +35,12 @@ class LoadFormFieldListener
         // back to potential previous post data which has not been validated yet (e.g. you filled in the values on step 2
         // but then navigated back)
         if (!$postData->has($widget->name)) {
-            $widget->value = $stepData->getSubmitted()->get($widget->name, $stepData->getOriginalPostData()->get($widget->name));
+            $default = $stepData->getOriginalPostData()->get($widget->name);
+            if ($default === null) {
+                // If no value is found, the field may have a default value set per default.
+                $default = $widget->value;
+            }
+            $widget->value = $stepData->getSubmitted()->get($widget->name, $default);
         }
 
         return $widget;

--- a/src/EventListener/LoadFormFieldListener.php
+++ b/src/EventListener/LoadFormFieldListener.php
@@ -31,16 +31,15 @@ class LoadFormFieldListener
         // We only prefill the value if it was not submitted in this step.
         // If you submit a value in step 1, go to step 2, then go back to step 1 and submit a wrong value there, Contao
         // would display an error, but we'd prefill it again with the previous value which would make no sense.
-        // Moreover, we prefill with submitted data as priority (= validated submitted widget data) and otherwise fall
-        // back to potential previous post data which has not been validated yet (e.g. you filled in the values on step 2
-        // but then navigated back)
+        // We prefill in the following order:
+        // 1. Submitted data (= validated submitted widget data)
+        // 2. Fall back to potentially previously post data which has not been validated yet (e.g. you filled in the values
+        //    on step 2 but then navigated back)
+        // 3. The widget default value itself
         if (!$postData->has($widget->name)) {
-            $default = $stepData->getOriginalPostData()->get($widget->name);
-            if ($default === null) {
-                // If no value is found, the field may have a default value set per default.
-                $default = $widget->value;
-            }
-            $widget->value = $stepData->getSubmitted()->get($widget->name, $default);
+            $widget->value = $stepData->getSubmitted()->get(
+                $widget->name, $stepData->getOriginalPostData()->get($widget->name, $widget->value)
+            );
         }
 
         return $widget;


### PR DESCRIPTION
Thanks for this cool extension for Contao. I found a little bug with default fields values.

If a form uses fields with default values set in the backend form generator, the default values get los.
This PR checks if no post data is avaible and if the form fields has any default value instead to display.