### PR TITLE
Fix incorrect step count in multi-step form

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -447,7 +447,7 @@ class FormManager
                     ...$this->formFieldsPerStep[$lastStepIndex], // Last step
                 ];
 
-                unset($this->formFieldsPerStep[$lastStepIndex]);
+                array_pop($this->formFieldsPerStep);
             }
         }
 

--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -78,7 +78,19 @@ class FormManager
     {
         $this->prepare();
 
-        return \count(array_keys($this->formFieldsPerStep));
+        $count = 0;
+
+        // Get the number of steps based on the number of page breaks in the form fields
+        foreach ($this->formFieldsPerStep as $formFields) {
+            foreach ($formFields as $formField) {
+                if ($this->isPageBreak($formField)) {
+                    $count++;
+                    break;
+                }
+            }
+        }
+
+        return $count;
     }
 
     public function isValidFormFieldCombination(): bool

--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -439,7 +439,7 @@ class FormManager
 
         // If the last form field is not a page break, we need to merge the last step into the previous one
         if (!$isPageBreakLastFormField) {
-            $lastStepIndex = count($this->formFieldsPerStep) - 1;
+            $lastStepIndex = \count($this->formFieldsPerStep) - 1;
 
             $this->formFieldsPerStep[$lastStepIndex - 1] = [
                 ...$this->formFieldsPerStep[$lastStepIndex - 1], // Second last step

--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -439,14 +439,16 @@ class FormManager
 
         // If the last form field is not a page break, we need to merge the last step into the previous one
         if (!$isPageBreakLastFormField) {
-            $lastStepIndex = \count($this->formFieldsPerStep) - 1;
+            $lastStepIndex = count($this->formFieldsPerStep) - 1;
 
-            $this->formFieldsPerStep[$lastStepIndex - 1] = [
-                ...$this->formFieldsPerStep[$lastStepIndex - 1], // Second last step
-                ...$this->formFieldsPerStep[$lastStepIndex], // Last step
-            ];
+            if (isset($this->formFieldsPerStep[$lastStepIndex], $this->formFieldsPerStep[$lastStepIndex - 1])) {
+                $this->formFieldsPerStep[$lastStepIndex - 1] = [
+                    ...$this->formFieldsPerStep[$lastStepIndex - 1], // Second last step
+                    ...$this->formFieldsPerStep[$lastStepIndex], // Last step
+                ];
 
-            unset($this->formFieldsPerStep[$lastStepIndex]);
+                unset($this->formFieldsPerStep[$lastStepIndex]);
+            }
         }
 
         $this->prepared = true;


### PR DESCRIPTION
Ensure the number of real form steps is calculated based on actual page breaks, not just the keys in $this->formFieldsPerStep. This resolves issues where additional wrappers (e.g., fieldsets) or misordered page breaks caused extra, invalid steps to be included.